### PR TITLE
Create ratio system for simulation vs render distance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ group = project.maven_group
 repositories {
     mavenLocal()
     mavenCentral()
+    maven { url = 'https://maven.maxhenkel.de/repository/public' }
     maven { url = "https://maven.fabricmc.net/" }
 }
 

--- a/src/main/java/de/maxhenkel/renderdistance/ServerEvents.java
+++ b/src/main/java/de/maxhenkel/renderdistance/ServerEvents.java
@@ -23,7 +23,7 @@ public class ServerEvents {
             return;
         }
 
-        if (RenderDistance.SERVER_CONFIG.fixedRenderDistance.get() > 0) {
+        if (RenderDistance.SERVER_CONFIG.fixedSimulationDistance.get() > 0 && RenderDistance.SERVER_CONFIG.fixedRenderDistance.get() > 0) {
             return;
         }
 
@@ -32,36 +32,35 @@ public class ServerEvents {
             return;
         }
         double mspt = getAverageMSPT();
-        int renderDistance = playerList.getViewDistance();
-        int minRenderDistance = RenderDistance.SERVER_CONFIG.minRenderDistance.get();
-        int maxRenderDistance = RenderDistance.SERVER_CONFIG.maxRenderDistance.get();
+        int simulationDistance = playerList.getSimulationDistance();
+        int minSimulationDistance = RenderDistance.SERVER_CONFIG.minSimulationDistance.get();
+        int maxSimulationDistance = RenderDistance.SERVER_CONFIG.maxSimulationDistance.get();
         if (mspt > RenderDistance.SERVER_CONFIG.maxMspt.get()) {
-            if (renderDistance > minRenderDistance) {
-                setRenderDistance(playerList, Math.max(playerList.getViewDistance() - 1, minRenderDistance), mspt);
+            if (simulationDistance > minSimulationDistance) {
+                setSimulationDistance(playerList, Math.max(playerList.getSimulationDistance() - 1, minSimulationDistance), mspt);
             }
         } else if (mspt < RenderDistance.SERVER_CONFIG.minMspt.get()) {
-            if (renderDistance < maxRenderDistance) {
-                setRenderDistance(playerList, Math.min(playerList.getViewDistance() + 1, maxRenderDistance), mspt);
+            if (simulationDistance < maxSimulationDistance) {
+                setSimulationDistance(playerList, Math.min(playerList.getSimulationDistance() + 1, maxSimulationDistance), mspt);
             }
         }
     }
 
-    public static void setRenderDistance(PlayerList playerList, int distance) {
-        setRenderDistance(playerList, distance, -1D);
+    public static void setSimulationDistance(PlayerList playerList, int distance) {
+        setSimulationDistance(playerList, distance, -1D);
     }
 
-    public static void setRenderDistance(PlayerList playerList, int distance, double mspt) {
-        playerList.setViewDistance(distance);
-        if (mspt < 0D) {
-            RenderDistance.LOGGER.info("Set render distance to {}", playerList.getViewDistance());
-        } else {
-            RenderDistance.LOGGER.info("Set render distance to {} ({} mspt)", playerList.getViewDistance(), mspt);
-        }
-
-        if (RenderDistance.SERVER_CONFIG.changeSimulationDistance.get()) {
-            RenderDistance.LOGGER.info("Set simulation distance to {}", distance);
+    public static void setSimulationDistance(PlayerList playerList, int distance, double mspt) {
+        if (RenderDistance.SERVER_CONFIG.fixedSimulationDistance.get() < 1) {
             playerList.setSimulationDistance(distance);
-        }
+            RenderDistance.refreshDistances(playerList);
+            if (mspt < 0D) {
+                RenderDistance.LOGGER.info("Set simulation distance to {} (render: {})", playerList.getSimulationDistance(), playerList.getViewDistance());
+            } else {
+                RenderDistance.LOGGER.info("Set simulation distance to {}  (render: {}) ({} mspt)", playerList.getSimulationDistance(), playerList.getViewDistance(), mspt);
+            }
+        } else
+            RenderDistance.refreshDistances(playerList);
     }
 
     public double getAverageMSPT() {

--- a/src/main/java/de/maxhenkel/renderdistance/command/RenderDistanceCommands.java
+++ b/src/main/java/de/maxhenkel/renderdistance/command/RenderDistanceCommands.java
@@ -1,15 +1,21 @@
 package de.maxhenkel.renderdistance.command;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import de.maxhenkel.configbuilder.ConfigEntry;
 import de.maxhenkel.renderdistance.RenderDistance;
 import de.maxhenkel.renderdistance.ServerEvents;
+import de.maxhenkel.renderdistance.config.ServerConfig;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.TextComponent;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class RenderDistanceCommands {
 
@@ -20,39 +26,24 @@ public class RenderDistanceCommands {
 
         literalBuilder.then(Commands.literal("current").executes((context) -> {
             context.getSource().sendSuccess(
-                    new TextComponent("The current render distance is ")
+                    new TextComponent("The current simulation distance is ")
+                            .append(new TextComponent(String.valueOf(context.getSource().getServer().getPlayerList().getSimulationDistance())).withStyle(ChatFormatting.GREEN))
+                            .append(new TextComponent(" chunks, and current render distance is "))
                             .append(new TextComponent(String.valueOf(context.getSource().getServer().getPlayerList().getViewDistance())).withStyle(ChatFormatting.GREEN))
                             .append(new TextComponent(" chunks"))
                     , false);
             return 1;
         }));
 
-        literalBuilder.then(Commands.literal("set").requires((commandSource) -> commandSource.hasPermission(2))
-                .then(Commands.argument("amount", IntegerArgumentType.integer()).executes((context) -> {
-                    int renderDistance = IntegerArgumentType.getInteger(context, "amount");
+        literalBuilder.then(Commands.literal("fixed").requires((commandSource) -> commandSource.hasPermission(2))
+                .then(setDistanceConfigValue("render", config(c -> c.fixedRenderDistance)))
+                .then(setDistanceConfigValue("simulation", config(c -> c.fixedSimulationDistance)))
+                .then(setRatioConfigValue("ratio", config(c -> c.renderToSimulationRatio)))
+        );
 
-                    if (renderDistance <= 0 || renderDistance > 32) {
-                        throw ERROR_INVALID_RENDER_DISTANCE.create();
-                    }
-                    RenderDistance.SERVER_CONFIG.fixedRenderDistance.set(renderDistance);
-                    RenderDistance.SERVER_CONFIG.fixedRenderDistance.save();
-                    context.getSource().getServer().getPlayerList().setViewDistance(renderDistance);
-                    context.getSource().sendSuccess(
-                            new TextComponent("Successfully set the render distance to ")
-                                    .append(new TextComponent(String.valueOf(renderDistance)).withStyle(ChatFormatting.GREEN))
-                                    .append(new TextComponent(" chunks"))
-                            , false);
-                    return 1;
-                }))
-                .then(Commands.literal("auto").executes(context -> {
-                    RenderDistance.SERVER_CONFIG.fixedRenderDistance.set(0);
-                    RenderDistance.SERVER_CONFIG.fixedRenderDistance.save();
-                    context.getSource().sendSuccess(
-                            new TextComponent("Successfully set the render distance to ")
-                                    .append(new TextComponent("auto").withStyle(ChatFormatting.GREEN))
-                            , false);
-                    return 1;
-                }))
+        literalBuilder.then(Commands.literal("limit").requires((commandSource) -> commandSource.hasPermission(2))
+                .then(setMinMaxConfigValue("render", config(c -> c.minRenderDistance), config(c -> c.maxRenderDistance)))
+                .then(setMinMaxConfigValue("simulation", config(c -> c.minSimulationDistance), config(c -> c.maxSimulationDistance)))
         );
 
         literalBuilder.then(Commands.literal("mspt").executes((context) -> {
@@ -80,4 +71,72 @@ public class RenderDistanceCommands {
         dispatcher.register(literalBuilder);
     }
 
+    private static LiteralArgumentBuilder<CommandSourceStack> setDistanceConfigValue(String name, Supplier<ConfigEntry<Integer>> fixedDistanceEntry) {
+        return Commands.literal(name).then(Commands.argument("amount", IntegerArgumentType.integer()).executes((context) -> {
+            int renderDistance = IntegerArgumentType.getInteger(context, "amount");
+
+            if (renderDistance <= 0 || renderDistance > 32) {
+                throw ERROR_INVALID_RENDER_DISTANCE.create();
+            }
+            fixedDistanceEntry.get().set(renderDistance);
+            fixedDistanceEntry.get().save();
+            RenderDistance.refreshDistances(context.getSource().getServer().getPlayerList());
+            context.getSource().sendSuccess(
+                    new TextComponent("Successfully set the " + name + " distance to ")
+                            .append(new TextComponent(String.valueOf(renderDistance)).withStyle(ChatFormatting.GREEN))
+                            .append(new TextComponent(" chunks"))
+                    , false);
+            return 1;
+        }))
+                .then(Commands.literal("auto").executes(context -> {
+                    fixedDistanceEntry.get().set(0);
+                    fixedDistanceEntry.get().save();
+                    context.getSource().sendSuccess(
+                            new TextComponent("Successfully set the " + name + " distance to ")
+                                    .append(new TextComponent("auto").withStyle(ChatFormatting.GREEN))
+                            , false);
+                    return 1;
+                }));
+    }
+
+    private static LiteralArgumentBuilder<CommandSourceStack> setRatioConfigValue(String name, Supplier<ConfigEntry<Double>> ratioEntry) {
+        return Commands.literal(name).then(Commands.argument("ratio", DoubleArgumentType.doubleArg()).executes((context) -> {
+            double ratio = DoubleArgumentType.getDouble(context, "ratio");
+            ratioEntry.get().set(ratio);
+            ratioEntry.get().save();
+            RenderDistance.refreshDistances(context.getSource().getServer().getPlayerList());
+            context.getSource().sendSuccess(
+                    new TextComponent("Successfully set the view to simulation ratio distance to ")
+                            .append(new TextComponent(String.valueOf(ratio)).withStyle(ChatFormatting.GREEN))
+                            .append(new TextComponent("."))
+                    , false);
+            return 1;
+        }));
+    }
+
+    private static LiteralArgumentBuilder<CommandSourceStack> setMinMaxConfigValue(String name, Supplier<ConfigEntry<Integer>> minDistanceEntry, Supplier<ConfigEntry<Integer>> maxDistanceEntry) {
+        return Commands.literal(name)
+                .then(Commands.argument("min", IntegerArgumentType.integer())
+                        .then(Commands.argument("max", IntegerArgumentType.integer())
+                                .executes((context) -> {
+                                    int min = IntegerArgumentType.getInteger(context, "min");
+                                    int max = IntegerArgumentType.getInteger(context, "max");
+                                    minDistanceEntry.get().set(min);
+                                    minDistanceEntry.get().save();
+                                    maxDistanceEntry.get().set(max);
+                                    maxDistanceEntry.get().save();
+                                    context.getSource().sendSuccess(
+                                            new TextComponent("Successfully set the " + name + " distance min/max to ")
+                                                    .append(new TextComponent(String.valueOf(min)).withStyle(ChatFormatting.GREEN))
+                                                    .append(new TextComponent("-").withStyle(ChatFormatting.GRAY))
+                                                    .append(new TextComponent(String.valueOf(max)).withStyle(ChatFormatting.GREEN))
+                                                    .append(new TextComponent(" chunks"))
+                                            , false);
+                                    return 1;
+                                })));
+    }
+    
+    private static <T> Supplier<ConfigEntry<T>> config(Function<ServerConfig, ConfigEntry<T>> getter) {
+        return () -> getter.apply(RenderDistance.SERVER_CONFIG);
+    }
 }

--- a/src/main/java/de/maxhenkel/renderdistance/config/ServerConfig.java
+++ b/src/main/java/de/maxhenkel/renderdistance/config/ServerConfig.java
@@ -10,8 +10,11 @@ public class ServerConfig {
     public final ConfigEntry<Integer> tickInterval;
     public final ConfigEntry<Integer> minRenderDistance;
     public final ConfigEntry<Integer> maxRenderDistance;
+    public final ConfigEntry<Integer> minSimulationDistance;
+    public final ConfigEntry<Integer> maxSimulationDistance;
+    public final ConfigEntry<Double> renderToSimulationRatio;
     public final ConfigEntry<Integer> fixedRenderDistance;
-    public final ConfigEntry<Boolean> changeSimulationDistance;
+    public final ConfigEntry<Integer> fixedSimulationDistance;
 
     public ServerConfig(ConfigBuilder builder) {
         minMspt = builder.doubleEntry("min_mspt", 30D, 0D, 1000D);
@@ -19,8 +22,11 @@ public class ServerConfig {
         tickInterval = builder.integerEntry("tick_interval", 20 * 10, 20, Integer.MAX_VALUE);
         minRenderDistance = builder.integerEntry("min_render_distance", 10, 1, 32);
         maxRenderDistance = builder.integerEntry("max_render_distance", 32, 1, 32);
+        minSimulationDistance = builder.integerEntry("min_simulation_distance", 10, 1, 32);
+        maxSimulationDistance = builder.integerEntry("max_simulation_distance", 32, 1, 32);
+        renderToSimulationRatio = builder.doubleEntry("render_to_simulation_ratio", 2, 1, 4);
         fixedRenderDistance = builder.integerEntry("fixed_render_distance", 0, 0, 32);
-        changeSimulationDistance = builder.booleanEntry("change_simulation_distance", true);
+        fixedSimulationDistance = builder.integerEntry("fixed_simulation_distance", 0, 0, 32);
     }
 
 }


### PR DESCRIPTION
Current version of this plugin for 1.18 rather defeats the purpose of 1.18 update.  
Both simulation and view distance should be used separetly, this can be done in many way, i choosen the simplest one I can easly implement quickly for my friends server.  

In my version the performance calculation works only based on simulation performance, and view is just calculated using a ratio property. Additionally the view can be set to a static number and then simulation will still scale according to load. From quick testing simulation affect the performance much more, so thats simplest logical choice here.

More advanced modes could be added in future, like manually selecting ratio per level:
```
simulation:view
3:3
4:6
6:12
16:32
32:32
```
And mod could then generate in-between steps by this values based on ratio between 2 other steps, like: `3:3, 3:5, 4:6, 5:9, 6:12, 7:14, 8:16 ... 16:32, 17:32...` based on simple math to calculate steps between.  
Or do some stat work and figure out best way to scale them both separetly while keeping the server both playable and fun.

Some other options would be to also analyse ram usage for view distance, or network/amount of players itself.

But for now I believe this is still much better option than either not scaling simulation at all - and the mod because quite useless, or scaling it in the same way - and the mod just removed amazing 1.18 performance improvments of separating these 2 things.

I made these changes for my own server, just decided to share my approach, feel free to merge, create something own based on it, or just ignore. 