### PR TITLE
Implement scaling modes and scaling step mode

### DIFF
--- a/src/main/java/de/maxhenkel/renderdistance/command/RenderDistanceCommands.java
+++ b/src/main/java/de/maxhenkel/renderdistance/command/RenderDistanceCommands.java
@@ -1,25 +1,33 @@
 package de.maxhenkel.renderdistance.command;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import de.maxhenkel.configbuilder.ConfigEntry;
 import de.maxhenkel.renderdistance.RenderDistance;
 import de.maxhenkel.renderdistance.ServerEvents;
 import de.maxhenkel.renderdistance.config.ServerConfig;
+import de.maxhenkel.renderdistance.modes.ScalingSteps;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 
+import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class RenderDistanceCommands {
 
     public static final SimpleCommandExceptionType ERROR_INVALID_RENDER_DISTANCE = new SimpleCommandExceptionType(new TextComponent("Invalid render distance"));
+    public static final SimpleCommandExceptionType ERROR_INVALID_STEPS = new SimpleCommandExceptionType(new TextComponent("Invalid steps syntax, it should be comma separated array of simulation to render distances, like: 2:3,3:3-6,4:6,..."));
 
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher, boolean dedicated) {
         LiteralArgumentBuilder<CommandSourceStack> literalBuilder = Commands.literal("renderdistance");
@@ -35,10 +43,18 @@ public class RenderDistanceCommands {
             return 1;
         }));
 
-        literalBuilder.then(Commands.literal("fixed").requires((commandSource) -> commandSource.hasPermission(2))
+        literalBuilder.then(Commands.literal("set").requires((commandSource) -> commandSource.hasPermission(2))
                 .then(setDistanceConfigValue("render", config(c -> c.fixedRenderDistance)))
                 .then(setDistanceConfigValue("simulation", config(c -> c.fixedSimulationDistance)))
-                .then(setRatioConfigValue("ratio", config(c -> c.renderToSimulationRatio)))
+                .then(setRatioConfigValue())
+                .then(setScalingStepsConfigValue())
+                .then(setScalingModeConfigValue())
+        );
+
+        literalBuilder.then(Commands.literal("limit").requires((commandSource) -> commandSource.hasPermission(2))
+                .then(setMinMaxConfigValue("render", config(c -> c.minRenderDistance), config(c -> c.maxRenderDistance)))
+                .then(setMinMaxConfigValue("simulation", config(c -> c.minSimulationDistance), config(c -> c.maxSimulationDistance)))
+                .then(setMinMaxMsptConfigValue(config(c -> c.minMspt), config(c -> c.maxMspt)))
         );
 
         literalBuilder.then(Commands.literal("limit").requires((commandSource) -> commandSource.hasPermission(2))
@@ -75,12 +91,12 @@ public class RenderDistanceCommands {
         return Commands.literal(name).then(Commands.argument("amount", IntegerArgumentType.integer()).executes((context) -> {
             int renderDistance = IntegerArgumentType.getInteger(context, "amount");
 
-            if (renderDistance <= 0 || renderDistance > 32) {
+            if (renderDistance <= 0 || renderDistance > ServerConfig.MAX_RENDER) {
                 throw ERROR_INVALID_RENDER_DISTANCE.create();
             }
             fixedDistanceEntry.get().set(renderDistance);
             fixedDistanceEntry.get().save();
-            RenderDistance.refreshDistances(context.getSource().getServer().getPlayerList());
+            RenderDistance.refreshDistances();
             context.getSource().sendSuccess(
                     new TextComponent("Successfully set the " + name + " distance to ")
                             .append(new TextComponent(String.valueOf(renderDistance)).withStyle(ChatFormatting.GREEN))
@@ -99,12 +115,12 @@ public class RenderDistanceCommands {
                 }));
     }
 
-    private static LiteralArgumentBuilder<CommandSourceStack> setRatioConfigValue(String name, Supplier<ConfigEntry<Double>> ratioEntry) {
-        return Commands.literal(name).then(Commands.argument("ratio", DoubleArgumentType.doubleArg()).executes((context) -> {
+    private static LiteralArgumentBuilder<CommandSourceStack> setRatioConfigValue() {
+        return Commands.literal("ratio").then(Commands.argument("ratio", DoubleArgumentType.doubleArg()).executes((context) -> {
             double ratio = DoubleArgumentType.getDouble(context, "ratio");
-            ratioEntry.get().set(ratio);
-            ratioEntry.get().save();
-            RenderDistance.refreshDistances(context.getSource().getServer().getPlayerList());
+            RenderDistance.SERVER_CONFIG.renderToSimulationRatio.set(ratio);
+            RenderDistance.SERVER_CONFIG.renderToSimulationRatio.save();
+            RenderDistance.refreshDistances();
             context.getSource().sendSuccess(
                     new TextComponent("Successfully set the view to simulation ratio distance to ")
                             .append(new TextComponent(String.valueOf(ratio)).withStyle(ChatFormatting.GREEN))
@@ -114,28 +130,87 @@ public class RenderDistanceCommands {
         }));
     }
 
+    private static LiteralArgumentBuilder<CommandSourceStack> setScalingModeConfigValue() {
+        LiteralArgumentBuilder<CommandSourceStack> literal = Commands.literal("mode");
+        for (String mode : RenderDistance.scalingModes.getModes()) {
+            literal.then(Commands.literal(mode).executes((context) -> {
+                RenderDistance.SERVER_CONFIG.mode.set(mode);
+                RenderDistance.SERVER_CONFIG.mode.save();
+                context.getSource().sendSuccess(
+                        new TextComponent("Successfully set the scaling mode to ")
+                                .append(new TextComponent(mode).withStyle(ChatFormatting.GREEN))
+                                .append(new TextComponent("."))
+                        , false);
+                return 1;
+            }));
+        }
+        return literal;
+    }
+
+    private static LiteralArgumentBuilder<CommandSourceStack> setScalingStepsConfigValue() {
+        return Commands.literal("scalingSteps").then(Commands.argument("scalingSteps", StringArgumentType.string()).executes((context) -> {
+            String scalingSteps = StringArgumentType.getString(context, "scalingSteps");
+            try {
+                ScalingSteps validatedSteps = ScalingSteps.valueOf(scalingSteps);
+                assert validatedSteps.size() != 0;
+                RenderDistance.SERVER_CONFIG.scalingSteps.set(scalingSteps);
+                RenderDistance.SERVER_CONFIG.scalingSteps.save();
+                RenderDistance.SERVER_CONFIG.reloadScalingSteps();
+            } catch (Exception suppressed) {
+                CommandSyntaxException commandSyntaxException = ERROR_INVALID_STEPS.create();
+                commandSyntaxException.addSuppressed(suppressed);
+                throw commandSyntaxException;
+            }
+            context.getSource().sendSuccess(
+                    new TextComponent("Successfully set the steps to ")
+                            .append(new TextComponent(String.valueOf(RenderDistance.SERVER_CONFIG.getScalingSteps())).withStyle(ChatFormatting.GREEN))
+                            .append(new TextComponent("."))
+                    , false);
+            return 1;
+        }));
+    }
+
     private static LiteralArgumentBuilder<CommandSourceStack> setMinMaxConfigValue(String name, Supplier<ConfigEntry<Integer>> minDistanceEntry, Supplier<ConfigEntry<Integer>> maxDistanceEntry) {
+        return setMinMaxConfigValue(Integer.class, name, minDistanceEntry, maxDistanceEntry, (min, max) ->
+                new TextComponent("Successfully set the " + name + " distance min/max to ")
+                        .append(new TextComponent(String.valueOf(min)).withStyle(ChatFormatting.GREEN))
+                        .append(new TextComponent("-").withStyle(ChatFormatting.GRAY))
+                        .append(new TextComponent(String.valueOf(max)).withStyle(ChatFormatting.GREEN))
+                        .append(new TextComponent(" chunks"))
+        );
+    }
+
+    private static LiteralArgumentBuilder<CommandSourceStack> setMinMaxMsptConfigValue(Supplier<ConfigEntry<Double>> minEntry, Supplier<ConfigEntry<Double>> maxEntry) {
+        return setMinMaxConfigValue(Double.class, "mspt", minEntry, maxEntry, (min, max) ->
+                new TextComponent("Successfully set the mspt min/max to ")
+                        .append(new TextComponent(String.valueOf(min)).withStyle(ChatFormatting.GREEN))
+                        .append(new TextComponent("-").withStyle(ChatFormatting.GRAY))
+                        .append(new TextComponent(String.valueOf(max)).withStyle(ChatFormatting.GREEN))
+                        .append(new TextComponent("ms per tick."))
+        );
+    }
+
+    private static final Map<Class<?>, ArgumentType<?>> argumentTypes = Map.of(
+            Integer.class, IntegerArgumentType.integer(),
+            Double.class, DoubleArgumentType.doubleArg()
+    );
+
+    private static <T> LiteralArgumentBuilder<CommandSourceStack> setMinMaxConfigValue(Class<T> type, String name, Supplier<ConfigEntry<T>> minEntry, Supplier<ConfigEntry<T>> maxEntry, BiFunction<T, T, Component> successMessage) {
         return Commands.literal(name)
-                .then(Commands.argument("min", IntegerArgumentType.integer())
-                        .then(Commands.argument("max", IntegerArgumentType.integer())
+                .then(Commands.argument("min", argumentTypes.get(type))
+                        .then(Commands.argument("max", argumentTypes.get(type))
                                 .executes((context) -> {
-                                    int min = IntegerArgumentType.getInteger(context, "min");
-                                    int max = IntegerArgumentType.getInteger(context, "max");
-                                    minDistanceEntry.get().set(min);
-                                    minDistanceEntry.get().save();
-                                    maxDistanceEntry.get().set(max);
-                                    maxDistanceEntry.get().save();
-                                    context.getSource().sendSuccess(
-                                            new TextComponent("Successfully set the " + name + " distance min/max to ")
-                                                    .append(new TextComponent(String.valueOf(min)).withStyle(ChatFormatting.GREEN))
-                                                    .append(new TextComponent("-").withStyle(ChatFormatting.GRAY))
-                                                    .append(new TextComponent(String.valueOf(max)).withStyle(ChatFormatting.GREEN))
-                                                    .append(new TextComponent(" chunks"))
-                                            , false);
+                                    T min = context.getArgument("min", type);
+                                    T max = context.getArgument("max", type);
+                                    minEntry.get().set(min);
+                                    minEntry.get().save();
+                                    maxEntry.get().set(max);
+                                    maxEntry.get().save();
+                                    context.getSource().sendSuccess(successMessage.apply(min, max), false);
                                     return 1;
                                 })));
     }
-    
+
     private static <T> Supplier<ConfigEntry<T>> config(Function<ServerConfig, ConfigEntry<T>> getter) {
         return () -> getter.apply(RenderDistance.SERVER_CONFIG);
     }

--- a/src/main/java/de/maxhenkel/renderdistance/config/ServerConfig.java
+++ b/src/main/java/de/maxhenkel/renderdistance/config/ServerConfig.java
@@ -2,8 +2,13 @@ package de.maxhenkel.renderdistance.config;
 
 import de.maxhenkel.configbuilder.ConfigBuilder;
 import de.maxhenkel.configbuilder.ConfigEntry;
+import de.maxhenkel.renderdistance.modes.ScalingSteps;
+
+import java.util.List;
 
 public class ServerConfig {
+    public static final int MAX_RENDER = 32;
+    public static final int MAX_SIMULATION = 32;
 
     public final ConfigEntry<Double> minMspt;
     public final ConfigEntry<Double> maxMspt;
@@ -15,18 +20,30 @@ public class ServerConfig {
     public final ConfigEntry<Double> renderToSimulationRatio;
     public final ConfigEntry<Integer> fixedRenderDistance;
     public final ConfigEntry<Integer> fixedSimulationDistance;
+    public final ConfigEntry<String> scalingSteps;
+    public final ConfigEntry<String> mode;
+    private ScalingSteps scalingStepsValue = new ScalingSteps(List.of());
 
     public ServerConfig(ConfigBuilder builder) {
         minMspt = builder.doubleEntry("min_mspt", 30D, 0D, 1000D);
         maxMspt = builder.doubleEntry("max_mspt", 40D, 0D, 1000D);
         tickInterval = builder.integerEntry("tick_interval", 20 * 10, 20, Integer.MAX_VALUE);
-        minRenderDistance = builder.integerEntry("min_render_distance", 10, 1, 32);
-        maxRenderDistance = builder.integerEntry("max_render_distance", 32, 1, 32);
-        minSimulationDistance = builder.integerEntry("min_simulation_distance", 10, 1, 32);
-        maxSimulationDistance = builder.integerEntry("max_simulation_distance", 32, 1, 32);
+        minRenderDistance = builder.integerEntry("min_render_distance", 10, 1, MAX_RENDER);
+        maxRenderDistance = builder.integerEntry("max_render_distance", MAX_RENDER, 1, MAX_RENDER);
+        minSimulationDistance = builder.integerEntry("min_simulation_distance", 10, 1, MAX_SIMULATION);
+        maxSimulationDistance = builder.integerEntry("max_simulation_distance", MAX_SIMULATION, 1, MAX_SIMULATION);
         renderToSimulationRatio = builder.doubleEntry("render_to_simulation_ratio", 2, 1, 4);
-        fixedRenderDistance = builder.integerEntry("fixed_render_distance", 0, 0, 32);
-        fixedSimulationDistance = builder.integerEntry("fixed_simulation_distance", 0, 0, 32);
+        fixedRenderDistance = builder.integerEntry("fixed_render_distance", 0, 0, MAX_RENDER);
+        fixedSimulationDistance = builder.integerEntry("fixed_simulation_distance", 0, 0, MAX_SIMULATION);
+        mode = builder.stringEntry("mode", "steps");
+        scalingSteps = builder.stringEntry("scaling_steps", "default");
     }
 
+    public void reloadScalingSteps() {
+        scalingStepsValue = ScalingSteps.valueOf(scalingSteps.get());
+    }
+
+    public ScalingSteps getScalingSteps() {
+        return scalingStepsValue;
+    }
 }

--- a/src/main/java/de/maxhenkel/renderdistance/modes/FixedDistanceModeWrapper.java
+++ b/src/main/java/de/maxhenkel/renderdistance/modes/FixedDistanceModeWrapper.java
@@ -1,0 +1,57 @@
+package de.maxhenkel.renderdistance.modes;
+
+import de.maxhenkel.renderdistance.RenderDistance;
+
+public class FixedDistanceModeWrapper implements ScalingMode {
+    private final ScalingMode mode;
+
+    public FixedDistanceModeWrapper(ScalingMode mode) {this.mode = mode;}
+
+    @Override
+    public String name() {
+        return "fixed";
+    }
+
+    @Override
+    public PerfDistance startup() {
+        return normalize(mode.startup());
+    }
+
+    @Override
+    public PerfDistance scaleUp(PerfDistance current) {
+        return normalize(mode.scaleUp(current));
+    }
+
+    @Override
+    public PerfDistance scaleDown(PerfDistance current) {
+        return normalize(mode.scaleDown(current));
+    }
+
+    @Override
+    public PerfDistance normalize(PerfDistance current) {
+        Integer fixedSim = RenderDistance.SERVER_CONFIG.fixedSimulationDistance.get();
+        Integer fixedView = RenderDistance.SERVER_CONFIG.fixedRenderDistance.get();
+        if (fixedSim <= 0 && fixedView <= 0) {
+            return mode.normalize(current);
+        }
+        PerfDistance normalize = mode.normalize(current);
+        int correctSim = fixedSim > 0 ? fixedSim : normalize.getSimulationDistance();
+        int correctView = fixedView > 0 ? fixedView : normalize.getViewDistance();
+        if (correctSim == normalize.getSimulationDistance() && correctView == normalize.getViewDistance()) {
+            return normalize;
+        }
+        return new SimplePerfDistance(correctSim, correctView);
+    }
+
+    @Override
+    public int limitSimulationDistance(int sim) {
+        Integer fixedDistance = RenderDistance.SERVER_CONFIG.fixedSimulationDistance.get();
+        return fixedDistance > 0 ? fixedDistance : mode.limitSimulationDistance(sim);
+    }
+
+    @Override
+    public int limitViewDistance(int view) {
+        Integer fixedDistance = RenderDistance.SERVER_CONFIG.fixedRenderDistance.get();
+        return fixedDistance > 0 ? fixedDistance : mode.limitViewDistance(view);
+    }
+}

--- a/src/main/java/de/maxhenkel/renderdistance/modes/PerfDistance.java
+++ b/src/main/java/de/maxhenkel/renderdistance/modes/PerfDistance.java
@@ -1,0 +1,7 @@
+package de.maxhenkel.renderdistance.modes;
+
+public interface PerfDistance {
+    int getViewDistance();
+    
+    int getSimulationDistance();
+}

--- a/src/main/java/de/maxhenkel/renderdistance/modes/PreventBigJumpsModeWrapper.java
+++ b/src/main/java/de/maxhenkel/renderdistance/modes/PreventBigJumpsModeWrapper.java
@@ -1,0 +1,73 @@
+package de.maxhenkel.renderdistance.modes;
+
+import de.maxhenkel.renderdistance.RenderDistance;
+
+// big jumps (~linear to amount of chunks) can cause big lag when switching, so I limit increases to update up to 256 chunks per jump 
+// (a difference between 31 and 32 distance)
+public class PreventBigJumpsModeWrapper implements ScalingMode {
+    private static final int MAX_UPDATE = 256;
+    private final ScalingMode mode;
+
+    public PreventBigJumpsModeWrapper(ScalingMode mode) {
+        this.mode = mode;
+    }
+
+    @Override
+    public String name() {
+        return "noJumps";
+    }
+
+    @Override
+    public PerfDistance startup() {
+        return normalize(mode.startup());
+    }
+
+    @Override
+    public PerfDistance scaleUp(PerfDistance current) {
+        return filtered(mode.scaleUp(current), current);
+    }
+
+    @Override
+    public PerfDistance scaleDown(PerfDistance current) {
+        return filtered(mode.scaleDown(current), current);
+    }
+
+    private PerfDistance filtered(PerfDistance next, PerfDistance current) {
+        PerfDistance filtered = next;
+        int simChunkDiff = calculateChunkDifference(current.getSimulationDistance(), next.getSimulationDistance());
+        int viewChunkDiff = calculateChunkDifference(current.getViewDistance(), next.getViewDistance());
+        if (simChunkDiff > MAX_UPDATE || viewChunkDiff > MAX_UPDATE) {
+            filtered = new SimplePerfDistance(
+                    findAllowedUpdate(current.getSimulationDistance(), filtered.getSimulationDistance()),
+                    findAllowedUpdate(current.getViewDistance(), filtered.getViewDistance())
+            );
+        }
+        return filtered;
+    }
+
+    private int findAllowedUpdate(int from, int to) {
+        if (from == to) return from;
+        int direction = (to - from) / Math.abs(to - from);
+        int allowedUpdate = from;
+        int totalChunkDifference;
+        do {
+            allowedUpdate += direction;
+            totalChunkDifference = calculateChunkDifference(from, allowedUpdate);
+        } while (totalChunkDifference < MAX_UPDATE && allowedUpdate < to);
+        return allowedUpdate;
+    }
+
+    @Override
+    public PerfDistance normalize(PerfDistance current) {
+        return filtered(mode.normalize(current), RenderDistance.current());
+    }
+
+    private int calculateChunkDifference(int from, int to) {
+        return Math.abs(calculateChunksPerDistance(to) - calculateChunksPerDistance(from));
+    }
+
+    private int calculateChunksPerDistance(int distance) {
+        int size = distance * 2 + 1;
+        return size * size;
+    }
+}

--- a/src/main/java/de/maxhenkel/renderdistance/modes/RatioScalingMode.java
+++ b/src/main/java/de/maxhenkel/renderdistance/modes/RatioScalingMode.java
@@ -1,0 +1,45 @@
+package de.maxhenkel.renderdistance.modes;
+
+import de.maxhenkel.renderdistance.RenderDistance;
+
+public class RatioScalingMode implements ScalingMode {
+    @Override
+    public String name() {
+        return "ratio";
+    }
+
+    @Override
+    public PerfDistance normalize(PerfDistance current) {
+        return new SimplePerfDistance(current.getSimulationDistance(), calcView(current.getSimulationDistance()));
+    }
+
+    @Override
+    public PerfDistance scaleUp(PerfDistance current) {
+        int nextSim = limitSimulationDistance(current.getSimulationDistance() + 1);
+        if (current.getSimulationDistance() == nextSim) {
+            int nextView = limitViewDistance(current.getViewDistance() + 1);
+            if (current.getViewDistance() == nextView) {
+                return current;
+            }
+            return new SimplePerfDistance(nextSim, nextView);
+        }
+        return new SimplePerfDistance(nextSim, calcView(nextSim));
+    }
+
+    @Override
+    public PerfDistance scaleDown(PerfDistance current) {
+        int nextSim = limitSimulationDistance(current.getSimulationDistance() - 1);
+        if (current.getSimulationDistance() == nextSim) {
+            int nextView = limitViewDistance(current.getViewDistance() - 1);
+            if (current.getViewDistance() == nextView) {
+                return current;
+            }
+            return new SimplePerfDistance(nextSim, nextView);
+        }
+        return new SimplePerfDistance(nextSim, calcView(nextSim));
+    }
+
+    private int calcView(int sim) {
+        return limitViewDistance((int) (sim * RenderDistance.SERVER_CONFIG.renderToSimulationRatio.get()));
+    }
+}

--- a/src/main/java/de/maxhenkel/renderdistance/modes/ScalingMode.java
+++ b/src/main/java/de/maxhenkel/renderdistance/modes/ScalingMode.java
@@ -1,0 +1,32 @@
+package de.maxhenkel.renderdistance.modes;
+
+import de.maxhenkel.renderdistance.RenderDistance;
+
+public interface ScalingMode {
+    String name();
+
+    default PerfDistance startup() {
+        return normalize(new SimplePerfDistance(limitSimulationDistance(5), limitViewDistance(10)));
+    }
+
+    PerfDistance scaleUp(PerfDistance current);
+
+    PerfDistance scaleDown(PerfDistance current);
+
+    default PerfDistance normalize(PerfDistance current) {
+        int limitedSim = limitSimulationDistance(current.getSimulationDistance());
+        int limitedView = limitViewDistance(current.getViewDistance());
+        if (limitedSim == current.getSimulationDistance() && limitedView == current.getViewDistance()) {
+            return current;
+        }
+        return new SimplePerfDistance(limitedSim, limitedView);
+    }
+
+    default int limitSimulationDistance(int sim) {
+        return Math.max(Math.min(sim, RenderDistance.SERVER_CONFIG.maxSimulationDistance.get()), RenderDistance.SERVER_CONFIG.minSimulationDistance.get());
+    }
+
+    default int limitViewDistance(int view) {
+        return Math.max(Math.min(view, RenderDistance.SERVER_CONFIG.maxRenderDistance.get()), RenderDistance.SERVER_CONFIG.minRenderDistance.get());
+    }
+}

--- a/src/main/java/de/maxhenkel/renderdistance/modes/ScalingModes.java
+++ b/src/main/java/de/maxhenkel/renderdistance/modes/ScalingModes.java
@@ -1,0 +1,38 @@
+package de.maxhenkel.renderdistance.modes;
+
+import de.maxhenkel.renderdistance.RenderDistance;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class ScalingModes {
+    private final Map<String, ScalingMode> modes = new HashMap<>();
+
+    {
+        addScalingMode(new RatioScalingMode());
+        addScalingMode(new StepsScalingMode());
+    }
+
+    public Set<String> getModes() {
+        return modes.keySet();
+    }
+
+    public void addScalingMode(ScalingMode scalingMode) {
+        this.modes.put(scalingMode.name(), wrap(scalingMode));
+    }
+
+    public ScalingMode wrap(ScalingMode scalingMode) {
+        // fixed might be more important, but doing big jumps can cause timeouts to all players so big jump preventions takes priority over fixed, 
+        // making changes to fixed range will result in fluent slow change to target value instead of 1 big lag.
+        return new PreventBigJumpsModeWrapper(new FixedDistanceModeWrapper(scalingMode));
+    }
+
+    public ScalingMode getScalingMode(String name) {
+        return this.modes.get(name);
+    }
+
+    public ScalingMode getScalingMode() {
+        return getScalingMode(RenderDistance.SERVER_CONFIG.mode.get());
+    }
+}

--- a/src/main/java/de/maxhenkel/renderdistance/modes/ScalingSteps.java
+++ b/src/main/java/de/maxhenkel/renderdistance/modes/ScalingSteps.java
@@ -1,0 +1,166 @@
+package de.maxhenkel.renderdistance.modes;
+
+import de.maxhenkel.renderdistance.config.ServerConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class ScalingSteps {
+    private final List<ScalingStep> steps;
+
+    public ScalingSteps(List<ScalingStep> steps) {
+        if (steps.isEmpty()) {
+            steps = DEFAULT_STEPS;
+        }
+        this.steps = steps;
+    }
+
+    public ScalingStep get(int mode) {
+        return this.steps.get(mode);
+    }
+
+    public static ScalingSteps valueOf(String toParse) {
+        if (toParse.trim().isEmpty() || toParse.equalsIgnoreCase("default")) {
+            return new ScalingSteps(List.of());
+        }
+        return new ScalingSteps(parse(toParse));
+    }
+
+    /*
+     Simple step format, where each element describe continuous range of possible view distances per simulation distance,
+     each element have a format of either `<simulation>:<view>` or `<simulation>:<viewMin>..<viewMax>`, elements are separated by comma,
+     additionally last element can be `...` to just generate rest of elements up to max of 32 by just incrementing both numbers each step.
+     */
+    private static List<ScalingStep> parse(String toParse) {
+        String[] elements = toParse.trim().split("[ |,;]");
+        List<ScalingStep> steps = new ArrayList<>(elements.length);
+        for (int j = 0; j < elements.length; j++) {
+            String element = elements[j];
+            if (element.equals("...") && j == elements.length - 1) {
+                ScalingStep lastStep = steps.get(steps.size() - 1);
+                for (int sim = lastStep.simulationDistance + 1, view = lastStep.viewDistance; sim <= ServerConfig.MAX_SIMULATION || view <= ServerConfig.MAX_RENDER; sim++, view++) {
+                    steps.add(new ScalingStep(Math.min(sim, ServerConfig.MAX_SIMULATION), Math.min(view, ServerConfig.MAX_RENDER)));
+                }
+                break;
+            }
+            String[] stepString = element.trim().split("[:]");
+            int simDistance = Integer.parseInt(stepString[0]);
+            String[] viewDistances = stepString[1].split("(-|\\.{1,3})", 2);
+            int from = Integer.parseInt(viewDistances[0]);
+            int to = viewDistances.length == 1 ? from : Integer.parseInt(viewDistances[1]);
+            for (int i = from; i <= to; i++) {
+                steps.add(new ScalingStep(simDistance, i));
+            }
+        }
+        return steps;
+    }
+
+    public List<ScalingStep> getSteps() {
+        return steps;
+    }
+
+    public int size() {
+        return steps.size();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder toString = new StringBuilder(steps.size() * 7);
+        int startView = -1;
+        int maxContView = 0;
+        int lastSim = 0;
+        for (ScalingStep step : steps) {
+            if (lastSim == 0) {
+                lastSim = step.simulationDistance;
+            } else if (lastSim != step.simulationDistance) {
+                appendStep(toString, startView, maxContView, lastSim).append(',');
+                startView = -1;
+            }
+            if (startView == -1) {
+                startView = step.viewDistance;
+                maxContView = startView;
+            } else if (step.viewDistance == maxContView + 1) {
+                maxContView = step.viewDistance;
+            } else {
+                appendStep(toString, startView, maxContView, lastSim).append(',');
+                startView = step.viewDistance;
+                maxContView = startView;
+            }
+            lastSim = step.simulationDistance;
+        }
+        appendStep(toString, startView, maxContView, lastSim);
+        return toString.toString();
+    }
+
+    private StringBuilder appendStep(StringBuilder toString, int minView, int maxView, int lastSim) {
+        toString.append(lastSim)
+                .append(':')
+                .append(minView);
+        if (minView != maxView) {
+            toString.append("..")
+                    .append(maxView);
+        }
+        return toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ScalingSteps that = (ScalingSteps) o;
+        return Objects.equals(steps, that.steps);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(steps);
+    }
+
+    public static class ScalingStep implements PerfDistance, Comparable<PerfDistance> {
+        final int simulationDistance;
+        final int viewDistance;
+
+        public ScalingStep(int simulationDistance, int viewDistance) {
+            this.simulationDistance = simulationDistance;
+            this.viewDistance = viewDistance;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ScalingStep that = (ScalingStep) o;
+            return viewDistance == that.viewDistance && simulationDistance == that.simulationDistance;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(viewDistance, simulationDistance);
+        }
+
+        @Override
+        public String toString() {
+            return simulationDistance + ":" + viewDistance;
+        }
+
+        @Override
+        public int getViewDistance() {
+            return viewDistance;
+        }
+
+        @Override
+        public int getSimulationDistance() {
+            return simulationDistance;
+        }
+
+        @Override
+        public int compareTo(PerfDistance o) {
+            return Integer.compare(this.simulationDistance, o.getSimulationDistance());
+        }
+    }
+
+    public static final String DEFAULT_STEPS_STRING = "2:2..5,3:6..7,4:8,5:9..10,6:12,7:14,8:16,8:18,8:20,8:22,9:22,10:22..32,11:32,...";
+
+    public static final List<ScalingStep> DEFAULT_STEPS = parse(DEFAULT_STEPS_STRING);
+}

--- a/src/main/java/de/maxhenkel/renderdistance/modes/SimplePerfDistance.java
+++ b/src/main/java/de/maxhenkel/renderdistance/modes/SimplePerfDistance.java
@@ -1,0 +1,13 @@
+package de.maxhenkel.renderdistance.modes;
+
+public record SimplePerfDistance(int simulationDistance, int viewDistance) implements PerfDistance {
+    @Override
+    public int getViewDistance() {
+        return viewDistance;
+    }
+
+    @Override
+    public int getSimulationDistance() {
+        return simulationDistance;
+    }
+}

--- a/src/main/java/de/maxhenkel/renderdistance/modes/StepsScalingMode.java
+++ b/src/main/java/de/maxhenkel/renderdistance/modes/StepsScalingMode.java
@@ -1,0 +1,76 @@
+package de.maxhenkel.renderdistance.modes;
+
+import de.maxhenkel.renderdistance.RenderDistance;
+import de.maxhenkel.renderdistance.modes.ScalingSteps.ScalingStep;
+import de.maxhenkel.renderdistance.config.ServerConfig;
+
+public class StepsScalingMode implements ScalingMode {
+    private int currentStep;
+
+    @Override
+    public String name() {
+        return "steps";
+    }
+
+    @Override
+    public PerfDistance startup() {
+        currentStep = RenderDistance.SERVER_CONFIG.getScalingSteps().getSteps().size() / 3;
+        return current();
+    }
+
+    public ScalingStep current() {
+        ScalingSteps scalingSteps = RenderDistance.SERVER_CONFIG.getScalingSteps();
+        return scalingSteps.get(this.currentStep = Math.min(scalingSteps.size() - 1, Math.max(this.currentStep, 0)));
+    }
+
+    @Override
+    public PerfDistance scaleUp(PerfDistance current) {
+        return move(current, 1);
+    }
+
+    @Override
+    public PerfDistance scaleDown(PerfDistance current) {
+        return move(current, -1);
+    }
+
+    private ScalingStep move(PerfDistance from, int by) {
+        if (by == 0) return current();
+        int direction = by / Math.abs(by);
+        ScalingStep current = current();
+
+        // to prevent increases while limits are active
+        if (direction == 1) {
+            if (limitSimulationDistance(current.getSimulationDistance()) > from.getSimulationDistance() ||
+                    limitViewDistance(current.getViewDistance()) > from.getViewDistance()) {
+                return current;
+            }
+        } else {
+            if (limitSimulationDistance(current.getSimulationDistance()) < from.getSimulationDistance() ||
+                    limitViewDistance(current.getViewDistance()) < from.getViewDistance()) {
+                return current;
+            }
+        }
+
+        currentStep += by;
+        ScalingStep next = current();
+        if (current == next) {
+            return next;
+        }
+        if (current.equals(next)) {
+            return move(from, direction);
+        }
+        if (!wouldSwitchingToStepDoAnything(next, from)) {
+            return move(from, direction);
+        }
+        return next;
+    }
+
+    private boolean wouldSwitchingToStepDoAnything(ScalingStep step, PerfDistance from) {
+        int curView = from.getViewDistance();
+        int curSim = from.getSimulationDistance();
+        ServerConfig config = RenderDistance.SERVER_CONFIG;
+        int nextView = Math.min(Math.max(step.getViewDistance(), config.minRenderDistance.get()), config.maxRenderDistance.get());
+        int nextSim = Math.min(Math.max(step.getSimulationDistance(), config.minSimulationDistance.get()), config.maxSimulationDistance.get());
+        return curView != nextView || curSim != nextSim;
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -5,7 +5,8 @@
   "name": "Dynamic Render Distance",
   "description": "Dynamic Render Distance",
   "authors": [
-    "Max Henkel"
+    "Max Henkel",
+    "GotoFinal"
   ],
   "contact": {
     "website": "https://modrepo.de"


### PR DESCRIPTION
As follow up to my other PR #3 I've made improvments to the system.... that kinda changed a lot, so i will understand if you will not be interested in merging this.

As this PR adds full support for multiple modes of scaling, and decorators/wrappers (not configurable now, could be done, but i dont see benefits for now), there is old ratio one, and more advanced one with manually defined steps using ranges.

Additionaly I've added a wrapper that avoids sudden changes in distances, as during testing i once change render distance from 32 to 10 and half of my players timeouted... So now sudden changes are limited to changing only 256 chunks at once (could be extracted to config) but will continue with each next check of mspt.

Might require a bit more testing, didn't use this yet with more people online.